### PR TITLE
Fixed Twitter and Github social links in profiles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+static_src/
 
 # Installer logs
 pip-log.txt
@@ -78,3 +79,5 @@ static/dist
 .env
 /venv/
 /src
+/env/
+

--- a/README.md
+++ b/README.md
@@ -107,6 +107,37 @@ $ python manage.py brunchserver
 
 Abre tu browser en [http://localhost:8000/](http://localhost:8000/). Para accesar la sección de administración ve a [http://localhost:8000/admin/](http://localhost:8000/admin/), y usa el username **admin** y el password **abc123**.
 
+##### Para los usuarios de Mac OSX
+Durante la instalacion de los requerimientos con pip:
+
+```bash
+$ pip install -r requirements.txt
+```
+Es posible que se encuentren con este error:
+
+```
+src/_pylibmcmodule.h:42:10: fatal error: 'libmemcached/memcached.h' file not found
+    #include <libmemcached/memcached.h>
+             ^
+    1 error generated.
+```
+
+Esto se puede dar cuando __libmemcached__ no esta instalada en su sistema. La solucion es instalar __libmemcached__ de una de las siguientes maneras:
+
+__Homebrew__
+
+```bash
+$ brew install libmemcached
+```
+
+__Ports__
+
+```bash
+$ sudo port install libmemcached
+```
+
+Una vez hecho esto pueden volver al paso ```$ pip install -r requirements.txt``` y continuar con las instrucciones.
+
 #### Para correr tests
 ```
 $ python manage.py test --configuration=Testing --verbosity=3 --noinput

--- a/apps/profiles/templates/profiles/profile_sidebar.html
+++ b/apps/profiles/templates/profiles/profile_sidebar.html
@@ -33,10 +33,10 @@
                 <li><a href="{{ profile_user.linkedin_url }}">LinkedIn</a></li>
             {% endif %}
             {% if profile_user.github_username %}
-                <li><a href="http://github.com/{{ profile_user.username }}">GitHub</a></li>
+                <li><a href="http://github.com/{{ profile_user.github_username }}">GitHub</a></li>
             {% endif %}
             {% if profile_user.twitter_username %}
-                <li><a href="http://twitter.com/{{ profile_user.username }}">Twitter</a></li>
+                <li><a href="http://twitter.com/{{ profile_user.twitter_username }}">Twitter</a></li>
             {% endif %}
             {% if profile_user.website_url %}
                 <li><a href="{{ profile_user.website_url }}">{{ profile_user.website_url }}</a></li>


### PR DESCRIPTION
Fixed social profile links, the twitter and github link were being created with the username and not the social account username.

**Github link error**
![horas_github_link_bug](https://cloud.githubusercontent.com/assets/1918027/2954570/91237dee-da74-11e3-832a-f04065e1a20a.png)

**Github link fixed**
![horas_github_link_fixed](https://cloud.githubusercontent.com/assets/1918027/2954687/7a02b650-da76-11e3-9cfd-9164328baed7.png)

**Twitter link error**
![horas_twitter_link_bug](https://cloud.githubusercontent.com/assets/1918027/2954606/405b0e62-da75-11e3-9b80-e56458007d05.png)

**Twitter link fixed**
![horas_twitter_link_fixed](https://cloud.githubusercontent.com/assets/1918027/2954692/8dc63b6c-da76-11e3-9ba8-65c81316152f.png)

Added some instructions to handle missing libmemcached lib for Mac OS X to the README.md
Added some more entries to the .gitignore fils
