### PR TITLE
Remove persona included template

### DIFF
--- a/apps/core/templates/home.html
+++ b/apps/core/templates/home.html
@@ -11,8 +11,6 @@
 {% endblock header %}
 
 {% block content %}
-    {% include "persona/auth.html" %}
-
     <div class="container">
         <div class="row">
             <div class="col-sm-12 home-branding-wrapper">


### PR DESCRIPTION
Fixes this error after removing persona provider.

```
Exception raised while rendering {% include %} for template 'home.html'. Empty string rendered instead.
Traceback (most recent call last):
  File "/Users/jpadilla/.pyenv/versions/horas/lib/python2.7/site-packages/django/template/loader_tags.py", line 201, in render
    template = context.template.engine.get_template(template_name)
  File "/Users/jpadilla/.pyenv/versions/horas/lib/python2.7/site-packages/django/template/engine.py", line 160, in get_template
    template, origin = self.find_template(template_name)
  File "/Users/jpadilla/.pyenv/versions/horas/lib/python2.7/site-packages/django/template/engine.py", line 146, in find_template
    raise TemplateDoesNotExist(name, tried=tried)
TemplateDoesNotExist: persona/auth.html
```